### PR TITLE
Solves duplicate points and triangle errors

### DIFF
--- a/app/Components/TileExporter/Exporter.js
+++ b/app/Components/TileExporter/Exporter.js
@@ -1,6 +1,10 @@
 import d3 from 'd3'
 import THREE from 'three'
 
+import './Triangulation'
+// Changes the way Threejs does triangulation
+THREE.Triangulation.setLibrary('earcut');
+
 import D3d from './D3-Three'
 import OBJExporter from './OBJ-Exporter';
 

--- a/app/Components/TileExporter/MapSpells.js
+++ b/app/Components/TileExporter/MapSpells.js
@@ -1,0 +1,19 @@
+////here all maps spells are!
+//convert lat/lon to mercator style number
+function long2tile(lon,zoom) {
+  return (Math.floor((lon+180)/360*Math.pow(2,zoom)));
+}
+function lat2tile(lat,zoom)  {
+  return (Math.floor((1-Math.log(Math.tan(lat*Math.PI/180) + 1/Math.cos(lat*Math.PI/180))/Math.PI)/2 *Math.pow(2,zoom)));
+}
+
+//shold check it will work
+function tile2Lon(tileLon, zoom) {
+  return (tileLon*360/Math.pow(2,zoom)-180).toFixed(10);
+}
+
+function tile2Lat(tileLat, zoom) {
+  return ((360/Math.PI) * Math.atan(Math.pow( Math.E, (Math.PI - 2*Math.PI*tileLat/(Math.pow(2,zoom)))))-90).toFixed(10);
+}
+
+module.exports = {long2tile, lat2tile, tile2Lon, tile2Lat};

--- a/app/Components/TileExporter/PreviewMap.js
+++ b/app/Components/TileExporter/PreviewMap.js
@@ -1,4 +1,5 @@
 import d3 from 'd3'
+import {tile2Lon, tile2Lat} from './MapSpells';
 
 import Key from '../../Keys'
 
@@ -176,13 +177,5 @@ var PreviewMap = (function() {
   }
 })();
 
-
-function tile2Lon(tileLon, zoom) {
-  return (tileLon*360/Math.pow(2,zoom)-180).toFixed(10);
-}
-
-function tile2Lat(tileLat, zoom) {
-  return ((360/Math.PI) * Math.atan(Math.pow( Math.E, (Math.PI - 2*Math.PI*tileLat/(Math.pow(2,zoom)))))-90).toFixed(10);
-}
 
 module.exports = PreviewMap

--- a/app/Components/TileExporter/Triangulation.js
+++ b/app/Components/TileExporter/Triangulation.js
@@ -1,0 +1,355 @@
+'use strict';
+
+/* Found on https://github.com/Wilt/three.js_triangulation
+ * Solves the problem of triangulation found in ThreeJS
+ * Possible that one of these solution will be integrated
+ * in the future with ThreeJS.
+ * See this issue: https://github.com/mrdoob/three.js/issues/5959
+ */
+
+// if ( ! window.THREE ) throw new Error( 'ERROR: three.js not loaded' );
+import THREE from 'three'
+import earcut from 'earcut'
+
+THREE.Triangulation = ( function() {
+
+    var timer = {
+
+        enabled: false,
+        start: null,
+        end: null
+
+    };
+
+    var library = 'original';
+
+    /**
+     * Names of the supported libraries
+     *
+     * @type {{original: string, earcut: string, poly2tri: string, libtess: string}}
+     */
+    var libraries = {
+        original: 'original',
+        earcut: 'earcut',
+        poly2tri: 'poly2tri',
+        libtess: 'libtess'
+    };
+
+    /**
+     * Container object for holding the different library adapters
+     *
+     * @type {{}}
+     */
+    var adapters = {};
+
+    adapters[ libraries.original ] = {
+
+        triangulate: THREE.ShapeUtils.triangulate,
+
+        triangulateShape: THREE.ShapeUtils.triangulateShape
+
+    };
+
+    adapters[ libraries.earcut ] = {
+
+        triangulateShape: function( contour, holes ) {
+
+            var i, il, dim = 2, array;
+            var holeIndices = [];
+            var points = [];
+
+            addPoints( contour );
+
+            for ( i = 0, il = holes.length; i < il; i ++ ) {
+
+                holeIndices.push( points.length / dim );
+
+                addPoints( holes[ i ] );
+
+            }
+
+            array = earcut( points, holeIndices, dim );
+
+            var result = [];
+
+            for ( i = 0, il = array.length; i < il; i += 3 ) {
+
+                result.push( array.slice( i, i + 3 ) );
+
+            }
+
+            return result;
+
+            function addPoints( a ) {
+
+                var i, il = a.length;
+
+                for ( i = 0; i < il; i ++ ) {
+
+                    points.push( a[ i ].x, a[ i ].y );
+
+                }
+
+            }
+
+        }
+
+    };
+
+    adapters[ libraries.poly2tri ] = {
+
+        triangulateShape: function( contour, holes ) {
+
+            var i, il, object, sweepContext, triangles;
+            var pointMap = {}, count = 0;
+
+            points = makePoints( contour );
+
+            sweepContext = new poly2tri.SweepContext( points );
+
+            for ( i = 0, il = holes.length; i < il; i ++ ) {
+
+                points = makePoints( holes[ i ] );
+
+                sweepContext.addHole( points );
+
+                points = points.concat( points );
+
+            }
+
+            object = sweepContext.triangulate();
+
+            triangles = object.triangles_;
+
+            var a, b, c, points, result = [];
+
+            for ( i = 0, il = triangles.length; i < il; i ++ ) {
+
+                points = triangles[ i ].points_;
+
+                a = pointMap[ points[ 0 ].x + ',' + points[ 0 ].y ];
+                b = pointMap[ points[ 1 ].x + ',' + points[ 1 ].y ];
+                c = pointMap[ points[ 2 ].x + ',' + points[ 2 ].y ];
+
+                result.push( [ a, b, c ] );
+
+            }
+
+            return result;
+
+            function makePoints( a ) {
+
+                var i, il = a.length,
+                    points = [];
+
+                for ( i = 0; i < il; i ++ ) {
+
+                    points.push( new poly2tri.Point( a[ i ].x, a[ i ].y ) );
+                    pointMap[ a[ i ].x + ',' + a[ i ].y ] = count;
+                    count ++;
+
+                }
+
+                return points;
+
+            }
+
+        }
+
+    };
+
+    adapters[ libraries.libtess ] = {
+
+        triangulateShape: function( contour, holes ) {
+
+            var i, il, triangles = [];
+            var pointMap = {}, count = 0;
+
+            // libtess will take 3d verts and flatten to a plane for tesselation
+            // since only doing 2d tesselation here, provide z=1 normal to skip
+            // iterating over verts only to get the same answer.
+            // comment out to test normal-generation code
+            tessy.gluTessNormal( 0, 0, 1 );
+
+            tessy.gluTessBeginPolygon( triangles );
+
+            points = makePoints( contour );
+
+            for ( i = 0, il = holes.length; i < il; i ++ ) {
+
+                points = makePoints( holes[ i ] );
+
+            }
+
+            tessy.gluTessEndPolygon();
+
+            var a, b, c, points, result = [];
+
+            for ( i = 0, il = triangles.length; i < il; i += 6 ) {
+
+                a = pointMap[ triangles[ i ] + ',' + triangles[ i + 1 ]];
+                b = pointMap[ triangles[ i + 2 ] + ',' + triangles[ i + 3 ]];
+                c = pointMap[ triangles[ i + 4 ] + ',' + triangles[ i + 5 ]];
+
+                result.push( [ a, b, c ] );
+
+            }
+
+            return result;
+
+            function makePoints( a ) {
+
+                var i, il = a.length,
+                    coordinates;
+
+                tessy.gluTessBeginContour();
+
+                for ( i = 0; i < il; i ++ ) {
+
+                    coordinates = [ a[ i ].x, a[ i ].y, 0 ];
+                    tessy.gluTessVertex( coordinates, coordinates );
+                    pointMap[ a[ i ].x + ',' + a[ i ].y ] = count;
+                    count ++;
+
+                }
+
+                tessy.gluTessEndContour();
+
+                return points;
+
+            }
+
+        }
+
+    };
+
+    /**
+     * Initialize the library by attaching the triangulation methods to the three.js API
+     */
+    function init() {
+
+        checkDependencies( library );
+
+        if ( timer.enabled ) {
+
+            THREE.ShapeUtils.triangulate = function() {
+
+                return adapters[ library ].triangulate.apply( this, arguments );
+
+            };
+
+            THREE.ShapeUtils.triangulateShape = function() {
+
+                timer.start = Date.now();
+
+                var result = adapters[ library ].triangulateShape.apply( this, arguments );
+
+                timer.end = Date.now();
+
+                console.log( "%c " + library + ": " + ( timer.end - timer.start ) + "ms", 'color: #0000ff');
+
+                return result;
+
+            };
+
+        } else {
+
+            THREE.ShapeUtils.triangulate = adapters[ library ].triangulate;
+
+            THREE.ShapeUtils.triangulateShape = adapters[ library ].triangulateShape;
+
+        }
+
+    }
+
+    /**
+     * Checks dependencies needed for the current library
+     *
+     * @param library
+     */
+    function checkDependencies( library ) {
+
+        switch ( library ) {
+
+            case libraries.earcut:
+
+                // if ( ! window.earcut ) throw new Error( 'ERROR: earcut not loaded' );
+
+                break;
+
+            case libraries.poly2tri:
+
+                if ( ! window.poly2tri ) throw new Error( 'ERROR: poly2tri not loaded' );
+
+                break;
+
+            case libraries.libtess:
+
+                if ( ! window.tessy ) throw new Error( 'ERROR: libtess not loaded' );
+
+                break;
+
+        }
+
+    }
+
+    /**
+     * Set the current triangulation library
+     *
+     * @param name
+     */
+    function setLibrary( name ) {
+
+        if ( ! libraries.hasOwnProperty( name ) ) throw new Error( 'ERROR: unknown library ' + name );
+
+        library = name;
+
+        init();
+
+    }
+
+    /**
+     * Set timer for triangulation on/off
+     *
+     * @param boolean
+     */
+    function setTimer( boolean ) {
+
+        timer.enabled = boolean;
+
+        init();
+
+    }
+
+    /**
+     * Get total time in seconds
+     *
+     * @return number
+     */
+    function getTime() {
+
+        if( timer.enabled ){
+
+            return ( timer.end - timer.start );
+
+        }
+
+        return false;
+
+    }
+
+    init();
+
+    return {
+
+        libraries: libraries,
+
+        setTimer: setTimer,
+
+        getTime: getTime,
+
+        setLibrary: setLibrary
+
+    };
+
+} )();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "body-parser": "1.14.1",
     "d3": "^3.5.16",
+    "earcut": "^2.1.1",
     "file-loader": "0.8.4",
     "http-proxy": "1.11.2",
     "less": "2.5.3",


### PR DESCRIPTION
Hello @hanbyul-here 

Did two things here:

1. Removed and moved duplicate code. The Map spells as you named them were in both files. And some of the PreviewMap code was still called for no apparent reason inside Exporter.js
2. I was bothered by the `duplicate points` and `triangulate` errors from Threejs. So I dug up a little. This [issue](https://github.com/mrdoob/three.js/issues/5959) helped me solve it. I implemented the `earcut` solution from [this repo](https://github.com/Wilt/three.js_triangulation). Now we have a clean console. And normally all objects and path should be created correctly. Probably in future versions, Threejs will implement these solution in future releases.

Hope this suits you.